### PR TITLE
add dockerfile.gpu instruction

### DIFF
--- a/content/en/docs/local deploy guide/deploy.md
+++ b/content/en/docs/local deploy guide/deploy.md
@@ -267,7 +267,13 @@ zarf package create --confirm
 
 Additional considerations are necessary for GPU deployments:
 
-The package deployment command is modified for GPU deployments:
+Prior to `zarf package create --confirm`, you will need to perform a docker build:
+
+```bash
+docker build -f Dockerfile.gpu -t ghcr.io/defenseunicorns/leapfrogai/llamacpp:0.0.1 .
+```
+
+The package deployment command is also modified for GPU deployments:
 
 ```git
 # deploy


### PR DESCRIPTION
When I provided my initial feedback, I incorrectly believed that the `dockerfile.gpu` build step for the llama-cpp-python backend was no longer necessary. This PR is for putting that instruction back into the overall deployment instruction.